### PR TITLE
Implement resend activation mail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gem 'rails',          '5.0.0.1'
 gem 'bootstrap-sass', '3.3.6'
 gem 'faker',          '1.6.6'
 gem 'kaminari',       '0.17.0'
-gem 'i18n_generators','2.1.1'
+gem 'i18n_generators', '2.1.1'
 gem 'bcrypt',         '3.1.11'
 gem 'puma',           '3.4.0'
 gem 'sass-rails',     '5.0.6'
@@ -18,7 +19,7 @@ gem 'rubocop'
 group :development, :test do
   gem 'sqlite3', '1.3.11'
   gem 'byebug',  '9.0.0', platform: :mri
-  gem "rails-controller-testing"
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,16 +1,15 @@
+# frozen_string_literal: true
 class AccountActivationsController < ApplicationController
-
   def edit
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id]) # params[:id]ではactivation_tokenが参照される
       user.activate
       log_in user
-      flash[:success] = "九工大軽音楽部へようこそ！"
+      flash[:success] = '九工大軽音楽部へようこそ！'
       redirect_to user
     else
-      flash[:danger] = "アカウントの有効化に失敗しました"
+      flash[:danger] = 'アカウントの有効化に失敗しました'
       redirect_to root_url
     end
   end
-  
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,72 +1,69 @@
+# frozen_string_literal: true
 class PasswordResetsController < ApplicationController
-  
   # hidden_field_tagからメールアドレスを取得しユーザを設定
   before_action :get_user,   only: [:edit, :update]
-  
+
   # 正しいユーザーかどうか確認
   before_action :valid_user, only: [:edit, :update]
-  
+
   # 期限切れかどうかを確認する
   before_action :check_expiration, only: [:edit, :update]
-  
-  def new
-  end
+
+  def new; end
 
   def create
     @user = User.find_by(email: params[:password_reset][:email].downcase)
     if @user
       @user.create_reset_digest
       @user.send_password_reset_email
-      flash[:info] = "パスワード再設定のためのメールを送信しました"
+      flash[:info] = 'パスワード再設定のためのメールを送信しました'
       redirect_to root_url
     else
-      flash.now[:danger] = "指定のメールアドレスが見つかりません"
+      flash.now[:danger] = '指定のメールアドレスが見つかりません'
       render 'new'
     end
   end
 
-  def edit
-  end
-  
+  def edit; end
+
   def update
     if params[:user][:password].empty?
-      @user.errors.add(:password, "パスワードは空白にできません")
+      @user.errors.add(:password, 'パスワードは空白にできません')
       render 'edit'
     elsif @user.update_attributes(user_params)
       log_in @user
-      flash[:success] = "パスワードを再設定しました"
+      flash[:success] = 'パスワードを再設定しました'
       redirect_to @user
     else
       render 'edit'
     end
   end
-  
+
   private
-  
-    # ストロングパラメータ
-    def user_params
-      params.require(:user).permit(:password, :password_confirmation)
-    end
 
-    # hidden_field_tagからメールアドレスを取得
-    def get_user
-      @user = User.find_by(email: params[:email])
-    end
+  # ストロングパラメータ
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
 
-    # 正しいユーザーかどうか確認
-    def valid_user
-      unless (@user && @user.activated? &&
-              @user.authenticated?(:reset, params[:id]))
-        redirect_to root_url
-      end
+  # hidden_field_tagからメールアドレスを取得
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  # 正しいユーザーかどうか確認
+  def valid_user
+    unless @user && @user.activated? &&
+           @user.authenticated?(:reset, params[:id])
+      redirect_to root_url
     end
-    
-    # 期限切れかどうかを確認
-    def check_expiration
-      if @user.password_reset_expired?
-        flash[:danger] = "パスワード再設定の有効時間切れです"
-        redirect_to new_password_reset_url
-      end
+  end
+
+  # 期限切れかどうかを確認
+  def check_expiration
+    if @user.password_reset_expired?
+      flash[:danger] = 'パスワード再設定の有効時間切れです'
+      redirect_to new_password_reset_url
     end
-    
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,5 @@
 class SessionsController < ApplicationController
   
-  # アカウント有効化メール再送信用にユーザ情報を渡すためのグローバル変数(sessions#create・users#resendで使用)
-  $resend_email = nil
-  
   def new
     redirect_to current_user if logged_in?
   end
@@ -15,9 +12,8 @@ class SessionsController < ApplicationController
         params[:session][:remember_me] == '1' ? remember(user) : forget(user)   # クッキーにユーザIDと記憶トークンを保存（「入力項目を保存」にチェックが有る場合）
         redirect_back_or user
       else
-        $resend_email = user.email # users#resendにユーザのメールアドレスを渡す
         message  = "アカウントが有効化されていません<br>
-                      #{view_context.link_to "アカウント有効化メールを再送信", resend_users_path}"
+                      #{view_context.link_to "アカウント有効化メールを再送信", resend_user_path(user)}"
         flash[:warning] = message
         redirect_to root_url
       end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,8 @@
 class SessionsController < ApplicationController
   
+  # アカウント有効化メール再送信用にユーザ情報を渡すためのグローバル変数(sessions#create・users#resendで使用)
+  $resend_email = nil
+  
   def new
     redirect_to current_user if logged_in?
   end
@@ -12,7 +15,9 @@ class SessionsController < ApplicationController
         params[:session][:remember_me] == '1' ? remember(user) : forget(user)   # クッキーにユーザIDと記憶トークンを保存（「入力項目を保存」にチェックが有る場合）
         redirect_back_or user
       else
-        message  = "アカウントが有効化されていません"
+        $resend_email = user.email # users#resendにユーザのメールアドレスを渡す
+        message  = "アカウントが有効化されていません<br>
+                      #{view_context.link_to "アカウント有効化メールを再送信", resend_users_path}"
         flash[:warning] = message
         redirect_to root_url
       end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 class SessionsController < ApplicationController
-  
   def new
     redirect_to current_user if logged_in?
   end
@@ -8,11 +8,11 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
       if user.activated?
-        log_in user     # 一時セッションにユーザIDを保存
-        params[:session][:remember_me] == '1' ? remember(user) : forget(user)   # クッキーにユーザIDと記憶トークンを保存（「入力項目を保存」にチェックが有る場合）
+        log_in user # 一時セッションにユーザIDを保存
+        params[:session][:remember_me] == '1' ? remember(user) : forget(user) # クッキーにユーザIDと記憶トークンを保存（「入力項目を保存」にチェックが有る場合）
         redirect_back_or user
       else
-        message  = "アカウントが有効化されていません<br>
+        message = "アカウントが有効化されていません<br>
                       #{view_context.link_to "アカウント有効化メールを再送信", resend_user_path(user)}"
         flash[:warning] = message
         redirect_to root_url
@@ -27,5 +27,4 @@ class SessionsController < ApplicationController
     log_out if logged_in?
     redirect_to root_url
   end
-  
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,6 @@ class UsersController < ApplicationController
     @user = User.new
   end
   
-  # ユーザ作成前にbefore_create :create_activation_digestで有効化トークンとダイジェストを作成
   def create
     @user = User.new(user_params)
     if @user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,40 +1,40 @@
+# frozen_string_literal: true
 class UsersController < ApplicationController
-  
   before_action :logged_in_user, only: [:index, :show, :edit, :update, :destroy]
   before_action :correct_user,   only: [:edit, :update]
   before_action :admin_user,     only: :destroy
-  
+
   def index
     @users = User.where(activated: true).order(:created_at).reverse_order.page(params[:page])
   end
-  
+
   def show
     @user = User.find(params[:id])
   end
-  
+
   def new
     @user = User.new
   end
-  
+
   def create
     @user = User.new(user_params)
     if @user.save
       @user.send_activation_email
-      flash[:info] = "アカウント有効化のためのメールを送信しました"
+      flash[:info] = 'アカウント有効化のためのメールを送信しました'
       redirect_to root_url
     else
       render 'new'
     end
   end
-  
+
   def edit
     @user = User.find(params[:id])
   end
-  
+
   def update
     @user = User.find(params[:id])
     if @user.update_attributes(user_params)
-      flash[:success] = "プロフィールを更新しました"
+      flash[:success] = 'プロフィールを更新しました'
       redirect_to @user
     else
       render 'edit'
@@ -43,49 +43,48 @@ class UsersController < ApplicationController
 
   def destroy
     User.find(params[:id]).destroy
-    flash[:success] = "メンバーから削除しました"
+    flash[:success] = 'メンバーから削除しました'
     redirect_to users_url
   end
-  
+
   # アカウント有効化メールを再送信
   def resend
     @user = User.find(params[:id])
     if @user.save
       @user.send_activation_email
-      flash[:info] = "アカウント有効化のためのメールを再送信しました"
+      flash[:info] = 'アカウント有効化のためのメールを再送信しました'
     else
       flash[:danger] = "アカウント有効化のためのメールを送信できませんでした<br>
                         しばらく待ってから再度実行してください"
     end
     redirect_to :back
   end
-  
+
   private
 
-    # ストロングパラメータの設定
-    def user_params
-      params.require(:user).permit(:name, :email, :password,
-                                   :password_confirmation)
+  # ストロングパラメータの設定
+  def user_params
+    params.require(:user).permit(:name, :email, :password,
+                                 :password_confirmation)
+  end
+
+  # ログイン済みユーザーかどうか確認
+  def logged_in_user
+    unless logged_in?
+      store_location # アクセスしようとしたURLを記憶
+      flash[:danger] = 'ログインしてください'
+      redirect_to login_url
     end
-    
-    # ログイン済みユーザーかどうか確認
-    def logged_in_user
-      unless logged_in?
-        store_location  # アクセスしようとしたURLを記憶
-        flash[:danger] = "ログインしてください"
-        redirect_to login_url
-      end
-    end
-    
-    # 正しいユーザーかどうか確認
-    def correct_user
-      @user = User.find(params[:id])
-      redirect_to(root_url) unless current_user?(@user)
-    end
-    
-    # 管理者かどうか確認
-    def admin_user
-      redirect_to(root_url) unless current_user.admin?
-    end
-    
+  end
+
+  # 正しいユーザーかどうか確認
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to(root_url) unless current_user?(@user)
+  end
+
+  # 管理者かどうか確認
+  def admin_user
+    redirect_to(root_url) unless current_user.admin?
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,12 +16,12 @@ class UsersController < ApplicationController
     @user = User.new
   end
   
+  # ユーザ作成前にbefore_create :create_activation_digestで有効化トークンとダイジェストを作成
   def create
     @user = User.new(user_params)
     if @user.save
       @user.send_activation_email
       flash[:info] = "アカウント有効化のためのメールを送信しました"
-      
       redirect_to root_url
     else
       render 'new'
@@ -46,6 +46,16 @@ class UsersController < ApplicationController
     User.find(params[:id]).destroy
     flash[:success] = "メンバーから削除しました"
     redirect_to users_url
+  end
+  
+  # アカウント有効化メールを再送信
+  def resend
+    @user = User.find_by(email: $resend_email)
+    @user.create_activation_digest
+    @user.save
+    @user.send_activation_email
+    flash[:info] = "アカウント有効化のためのメールを再送信しました"
+    redirect_to :back
   end
   
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,9 +52,13 @@ class UsersController < ApplicationController
   def resend
     @user = User.find_by(email: $resend_email)
     @user.create_activation_digest
-    @user.save
-    @user.send_activation_email
-    flash[:info] = "アカウント有効化のためのメールを再送信しました"
+    if @user.save
+      @user.send_activation_email
+      flash[:info] = "アカウント有効化のためのメールを再送信しました"
+    else
+      flash[:danger] = "アカウント有効化のためのメールを送信できませんでした<br>
+                        しばらく待ってから再度実行してください"
+    end
     redirect_to :back
   end
   

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,8 +50,7 @@ class UsersController < ApplicationController
   
   # アカウント有効化メールを再送信
   def resend
-    @user = User.find_by(email: $resend_email)
-    @user.create_activation_digest
+    @user = User.find(params[:id])
     if @user.save
       @user.send_activation_email
       flash[:info] = "アカウント有効化のためのメールを再送信しました"

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 module AccountActivationsHelper
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,12 @@
+# frozen_string_literal: true
 module ApplicationHelper
-    
   # ページごとの完全なタイトルを返す
   def full_title(page_title = '')
-    base_title = "KIT WhiteBoard"
+    base_title = 'KIT WhiteBoard'
     if page_title.empty?
       base_title
-    else 
-      page_title + " | " + base_title 
+    else
+      page_title + ' | ' + base_title
     end
   end
-  
 end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 module PasswordResetsHelper
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,54 +1,54 @@
+# frozen_string_literal: true
 module SessionsHelper
-
   # 渡されたユーザーでログインする
   def log_in(user)
     session[:user_id] = user.id
   end
-  
+
   # ユーザーを永続的セッションに記憶する
   def remember(user)
-    user.remember   # 永続セッションのために記憶トークンをハッシュ化してDBに記憶する
+    user.remember # 永続セッションのために記憶トークンをハッシュ化してDBに記憶する
     cookies.permanent.signed[:user_id] = user.id
     cookies.permanent[:remember_token] = user.remember_token
   end
-  
+
   # 渡されたユーザーがログイン済みユーザーであればtrueを返す
   def current_user?(user)
     user == current_user
   end
-  
+
   # 記憶トークンcookieに対応するユーザーを返す
   def current_user
     if (user_id = session[:user_id])                # 新たにログインした場合
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])      # 一度ログイン済みでクッキーに情報が保存されている場合
       user = User.find_by(id: user_id)
-      if user && user.authenticated?(:remember, cookies[:remember_token])   # ユーザが存在し、クッキーの記憶トークンをハッシュ化したものと記憶ダイジェストが一致した場合
+      if user && user.authenticated?(:remember, cookies[:remember_token]) # ユーザが存在し、クッキーの記憶トークンをハッシュ化したものと記憶ダイジェストが一致した場合
         log_in user
         @current_user = user
       end
     end
   end
-  
+
   # ユーザーがログインしていればtrue、その他ならfalseを返す
   def logged_in?
     !current_user.nil?
   end
-  
+
   # 永続的セッションを破棄する（log_outメソッドで使用）
   def forget(user)
     user.forget
     cookies.delete(:user_id)
     cookies.delete(:remember_token)
   end
-  
+
   # 現在のユーザーをログアウトする
   def log_out
     forget(current_user)
     session.delete(:user_id)
     @current_user = nil
   end
-  
+
   # 記憶したURL (もしくはデフォルト値) にリダイレクト
   def redirect_back_or(default)
     redirect_to(session[:forwarding_url] || default)
@@ -59,5 +59,4 @@ module SessionsHelper
   def store_location
     session[:forwarding_url] = request.original_url if request.get?
   end
-  
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,12 +1,11 @@
+# frozen_string_literal: true
 module UsersHelper
-    
-  # TODO:リリース時は消すかも
+  # TODO: リリース時は消すかも
   # 引数で与えられたユーザーのGravatar画像を返す
   def gravatar_for(user, options = { size: 80 })
-    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
+    gravatar_id = Digest::MD5.hexdigest(user.email.downcase)
     size = options[:size]
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
-    image_tag(gravatar_url, alt: user.name, class: "gravatar")
+    image_tag(gravatar_url, alt: user.name, class: 'gravatar')
   end
-  
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
+# frozen_string_literal: true
 class ApplicationMailer < ActionMailer::Base
-  default from: "noreply@example.com"
+  default from: 'noreply@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,13 +1,12 @@
+# frozen_string_literal: true
 class UserMailer < ApplicationMailer
-
   def account_activation(user)
     @user = user
-    mail to: user.email, subject: "[WhiteBoard] アカウント有効化"
+    mail to: user.email, subject: '[WhiteBoard] アカウント有効化'
   end
 
   def password_reset(user)
     @user = user
-    mail to: user.email, subject: "[WhiteBoard] パスワード再設定"
+    mail to: user.email, subject: '[WhiteBoard] パスワード再設定'
   end
-  
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,17 +85,17 @@ class User < ApplicationRecord
       reset_sent_at < 1.hours.ago
     end
   
+    # 有効化トークンとダイジェストを作成および代入する
+    def create_activation_digest
+      self.activation_token  = User.new_token
+      self.activation_digest = User.digest(activation_token)
+    end
+      
     private
 
       # メールアドレスをすべて小文字にする
       def downcase_email
         self.email = email.downcase
       end
-  
-      # 有効化トークンとダイジェストを作成および代入する
-      def create_activation_digest
-        self.activation_token  = User.new_token
-        self.activation_digest = User.digest(activation_token)
-      end
-    
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
     before_save   :downcase_email
     
     # ユーザ作成前に有効化トークンとダイジェストを作成
-    before_create :create_activation_digest
+    before_save :create_activation_digest
     
     # nameのバリデーション
     validates :name,  presence: true, length: { maximum: 50 }
@@ -84,18 +84,18 @@ class User < ApplicationRecord
     def password_reset_expired?
       reset_sent_at < 1.hours.ago
     end
-  
-    # 有効化トークンとダイジェストを作成および代入する
-    def create_activation_digest
-      self.activation_token  = User.new_token
-      self.activation_digest = User.digest(activation_token)
-    end
       
     private
 
       # メールアドレスをすべて小文字にする
       def downcase_email
         self.email = email.downcase
+      end
+      
+      # 有効化トークンとダイジェストを作成および代入する
+      def create_activation_digest
+        self.activation_token  = User.new_token
+        self.activation_digest = User.digest(activation_token)
       end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,101 +1,99 @@
+# frozen_string_literal: true
 class User < ApplicationRecord
-    
-    # 記憶トークン・有効化トークン・パスワード再設定トークン用のクラス変数
-    attr_accessor :remember_token, :activation_token, :reset_token
-    
-    # ページネーションでの１ページの表示数
-    paginates_per  20
-    
-    # DB保存前にメールアドレスを小文字に
-    before_save   :downcase_email
-    
-    # ユーザ作成前に有効化トークンとダイジェストを作成
-    before_save :create_activation_digest
-    
-    # nameのバリデーション
-    validates :name,  presence: true, length: { maximum: 50 }
-    
-    # emailのバリデーション
-    VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i  # メールアドレスの正規表現
-    validates :email, presence: true
-    validates :email, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX },
-                      uniqueness: { case_sensitive: false },
-                      unless: Proc.new { |a| a.email.blank? } # メールアドレスが入力されている場合のみ確認
-    
-    # passwordのバリデーション
-    has_secure_password
-    validates :password, presence: true, length: { minimum: 6 }, allow_nil: true  # プロフ更新時のみnilを許可(パスはそのまま)
-    
-    
-    # 渡された文字列のハッシュ値を返す(フィクスチャ用)
-    def User.digest(string)
-      cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
-                                                    BCrypt::Engine.cost
-      BCrypt::Password.create(string, cost: cost)
-    end
-    
-    # ランダムなトークンを返す（rememberメソッドで使用）
-    def User.new_token
-      SecureRandom.urlsafe_base64
-    end
-    
-    # 永続セッションのために記憶トークンをハッシュ化してDBに記憶する
-    def remember
-      self.remember_token = User.new_token
-      update_attribute(:remember_digest, User.digest(remember_token))
-    end
-  
-    # 渡されたトークンがユーザのダイジェストと一致したらtrueを返す
-    # (記憶トークン・有効かトークンで兼用)
-    def authenticated?(attribute, token)
-      digest = send("#{attribute}_digest")
-      return false if digest.nil?
-      BCrypt::Password.new(digest).is_password?(token)
-    end
-  
-    # ユーザーのログイン情報（記憶ダイジェスト）をDBから破棄する
-    def forget
-      update_attribute(:remember_digest, nil)
-    end
-    
-    # アカウントを有効にする
-    def activate
-      update_columns(activated: true, activated_at: Time.zone.now)
-    end
-  
-    # 有効化用のメールを送信する
-    def send_activation_email
-      UserMailer.account_activation(self).deliver_now
-    end
-    
-    # パスワード再設定の属性を設定する
-    def create_reset_digest
-      self.reset_token = User.new_token
-      update_attribute(:reset_digest,  User.digest(reset_token))
-      update_attribute(:reset_sent_at, Time.zone.now)
-    end
-  
-    # パスワード再設定のメールを送信する
-    def send_password_reset_email
-      UserMailer.password_reset(self).deliver_now
-    end
-    
-    # パスワード再設定の期限が切れている場合はtrueを返す
-    def password_reset_expired?
-      reset_sent_at < 1.hours.ago
-    end
-      
-    private
+  # 記憶トークン・有効化トークン・パスワード再設定トークン用のクラス変数
+  attr_accessor :remember_token, :activation_token, :reset_token
 
-      # メールアドレスをすべて小文字にする
-      def downcase_email
-        self.email = email.downcase
-      end
-      
-      # 有効化トークンとダイジェストを作成および代入する
-      def create_activation_digest
-        self.activation_token  = User.new_token
-        self.activation_digest = User.digest(activation_token)
-      end
+  # ページネーションでの１ページの表示数
+  paginates_per 20
 
+  # DB保存前にメールアドレスを小文字に
+  before_save :downcase_email
+
+  # ユーザ作成前に有効化トークンとダイジェストを作成
+  before_save :create_activation_digest
+
+  # nameのバリデーション
+  validates :name,  presence: true, length: { maximum: 50 }
+
+  # emailのバリデーション
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i # メールアドレスの正規表現
+  validates :email, presence: true
+  validates :email, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX },
+                    uniqueness: { case_sensitive: false },
+                    unless: proc {|a| a.email.blank? } # メールアドレスが入力されている場合のみ確認
+
+  # passwordのバリデーション
+  has_secure_password
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true # プロフ更新時のみnilを許可(パスはそのまま)
+
+  # 渡された文字列のハッシュ値を返す(フィクスチャ用)
+  def self.digest(string)
+    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+                                                  BCrypt::Engine.cost
+    BCrypt::Password.create(string, cost: cost)
+  end
+
+  # ランダムなトークンを返す（rememberメソッドで使用）
+  def self.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  # 永続セッションのために記憶トークンをハッシュ化してDBに記憶する
+  def remember
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
+  end
+
+  # 渡されたトークンがユーザのダイジェストと一致したらtrueを返す
+  # (記憶トークン・有効かトークンで兼用)
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
+  end
+
+  # ユーザーのログイン情報（記憶ダイジェスト）をDBから破棄する
+  def forget
+    update_attribute(:remember_digest, nil)
+  end
+
+  # アカウントを有効にする
+  def activate
+    update_columns(activated: true, activated_at: Time.zone.now)
+  end
+
+  # 有効化用のメールを送信する
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
+  end
+
+  # パスワード再設定の属性を設定する
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_attribute(:reset_digest,  User.digest(reset_token))
+    update_attribute(:reset_sent_at, Time.zone.now)
+  end
+
+  # パスワード再設定のメールを送信する
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  # パスワード再設定の期限が切れている場合はtrueを返す
+  def password_reset_expired?
+    reset_sent_at < 1.hours.ago
+  end
+
+  private
+
+  # メールアドレスをすべて小文字にする
+  def downcase_email
+    self.email = email.downcase
+  end
+
+  # 有効化トークンとダイジェストを作成および代入する
+  def create_activation_digest
+    self.activation_token  = User.new_token
+    self.activation_digest = User.digest(activation_token)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
       
       <!-- フラッシュを表示-->
       <% flash.each do |message_type, message| %>
-        <div class="alert alert-<%= message_type %>"><%= message %></div>
+        <div class="alert alert-<%= message_type %>"><%= message.html_safe %></div> <!-- html形式で出力 -->
       <% end %>
       
       <%= yield %>

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError => e

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError => e

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 require 'pathname'
 require 'fileutils'
 include FileUtils

--- a/bin/spring
+++ b/bin/spring
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # This file loads spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
@@ -8,7 +9,7 @@ unless defined?(Spring)
   require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  if spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring = lockfile.specs.detect {|spec| spec.name == 'spring' }
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version
     require 'spring/binstub'

--- a/bin/update
+++ b/bin/update
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 require 'pathname'
 require 'fileutils'
 include FileUtils

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'boot'
 
 require 'rails/all'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Load the Rails application.
 require_relative 'application'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -18,7 +19,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=172800'
+      'Cache-Control' => 'public, max-age=172800',
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -48,7 +49,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -57,19 +58,19 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "whiteboard_#{Rails.env}"
   config.action_mailer.perform_caching = false
-  
+
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   host = 'kit-whiteboard.herokuapp.com'
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
-    :address        => 'smtp.sendgrid.net',
-    :port           => '587',
-    :authentication => :plain,
-    :user_name      => ENV['SENDGRID_USERNAME'],
-    :password       => ENV['SENDGRID_PASSWORD'],
-    :domain         => 'heroku.com',
-    :enable_starttls_auto => true
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: 'heroku.com',
+    enable_starttls_auto: true,
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -90,7 +91,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -15,7 +16,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => 'public, max-age=3600'
+    'Cache-Control' => 'public, max-age=3600',
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # ApplicationController.renderer.defaults.merge!(

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Kaminari.configure do |config|
   # config.default_per_page = 5
   # config.max_per_page = nil

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_whiteboard_session'

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,19 +1,20 @@
+# frozen_string_literal: true
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }.to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT') { 3_000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'
   resources :users do
-    collection do
+    member do
       get 'resend'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
 Rails.application.routes.draw do
-
-  # TODO:仮のルート
+  # TODO: 仮のルート
   root   'sessions#new'
-  
+
   get    '/signup',  to: 'users#new'
   post   '/signup',  to: 'users#create'
   get    '/login',   to: 'sessions#new'
@@ -15,5 +15,4 @@ Rails.application.routes.draw do
   end
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
-  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,11 @@ Rails.application.routes.draw do
   get    '/login',   to: 'sessions#new'
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'
-  resources :users
+  resources :users do
+    collection do
+      get 'resend'
+    end
+  end
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
   

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 %w(
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+).each {|path| Spring.watch(path) }

--- a/db/migrate/20161209073114_create_users.rb
+++ b/db/migrate/20161209073114_create_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CreateUsers < ActiveRecord::Migration[5.0]
   def change
     create_table :users do |t|

--- a/db/migrate/20161209074834_add_index_to_users_email.rb
+++ b/db/migrate/20161209074834_add_index_to_users_email.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddIndexToUsersEmail < ActiveRecord::Migration[5.0]
   def change
     add_index :users, :email, unique: true

--- a/db/migrate/20161209075123_add_password_digest_to_users.rb
+++ b/db/migrate/20161209075123_add_password_digest_to_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddPasswordDigestToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :password_digest, :string

--- a/db/migrate/20161210160733_add_remember_digest_to_users.rb
+++ b/db/migrate/20161210160733_add_remember_digest_to_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddRememberDigestToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :remember_digest, :string

--- a/db/migrate/20161210225802_add_admin_to_users.rb
+++ b/db/migrate/20161210225802_add_admin_to_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddAdminToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :admin, :boolean

--- a/db/migrate/20161211082031_add_activation_to_users.rb
+++ b/db/migrate/20161211082031_add_activation_to_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddActivationToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :activation_digest, :string

--- a/db/migrate/20161211151502_add_reset_to_users.rb
+++ b/db/migrate/20161211151502_add_reset_to_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddResetToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :reset_digest, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,22 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161211151502) do
-
-  create_table "users", force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.string   "password_digest"
-    t.string   "remember_digest"
-    t.boolean  "admin"
-    t.string   "activation_digest"
-    t.boolean  "activated",         default: false
-    t.datetime "activated_at"
-    t.string   "reset_digest"
-    t.datetime "reset_sent_at"
-    t.index ["email"], name: "index_users_on_email", unique: true
+ActiveRecord::Schema.define(version: 20_161_211_151_502) do
+  create_table 'users', force: :cascade do |t|
+    t.string   'name'
+    t.string   'email'
+    t.datetime 'created_at',                        null: false
+    t.datetime 'updated_at',                        null: false
+    t.string   'password_digest'
+    t.string   'remember_digest'
+    t.boolean  'admin'
+    t.string   'activation_digest'
+    t.boolean  'activated', default: false
+    t.datetime 'activated_at'
+    t.string   'reset_digest'
+    t.datetime 'reset_sent_at'
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
-
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 # 100人のテスト用ユーザを作成
 
 # 管理者
-User.create!(name:  "Ito Masafumi",
-             email: "mito@example.com",
-             password:              "foobar",
-             password_confirmation: "foobar",
+User.create!(name:  'Ito Masafumi',
+             email: 'mito@example.com',
+             password:              'foobar',
+             password_confirmation: 'foobar',
              admin: true,
              activated: true,
              activated_at: Time.zone.now)
@@ -12,8 +13,8 @@ User.create!(name:  "Ito Masafumi",
 # その他
 99.times do |n|
   name  = Faker::Name.name
-  email = "example-#{n+1}@example.com"
-  password = "password"
+  email = "example-#{n + 1}@example.com"
+  password = 'password'
   User.create!(name:  name,
                email: email,
                password:              password,

--- a/test/controllers/account_activations_controller_test.rb
+++ b/test/controllers/account_activations_controller_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class AccountActivationsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,9 +1,9 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class SessionsControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
+  test 'should get new' do
     get login_path
     assert_response :success
   end
-
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,48 +1,47 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
-  
   def setup
     @user       = users(:ito)
     @other_user = users(:soneda)
   end
-  
-  test "should get new" do
+
+  test 'should get new' do
     get new_user_path
     assert_response :success
   end
-  
-  test "should redirect index when not logged in" do
+
+  test 'should redirect index when not logged in' do
     get users_path
     assert_redirected_to login_url
   end
-  
-  test "should redirect edit when not logged in" do
+
+  test 'should redirect edit when not logged in' do
     get edit_user_path(@user)
     assert_not flash.empty?
     assert_redirected_to login_url
   end
 
-  test "should redirect update when not logged in" do
+  test 'should redirect update when not logged in' do
     patch user_path(@user), params: { user: { name: @user.name,
                                               email: @user.email } }
     assert_not flash.empty?
     assert_redirected_to login_url
   end
 
-  test "should redirect edit when logged in as wrong user" do
+  test 'should redirect edit when logged in as wrong user' do
     log_in_as(@other_user)
     get edit_user_path(@user)
     assert flash.empty?
     assert_redirected_to root_url
   end
 
-  test "should redirect update when logged in as wrong user" do
+  test 'should redirect update when logged in as wrong user' do
     log_in_as(@other_user)
     patch user_path(@user), params: { user: { name: @user.name,
                                               email: @user.email } }
     assert flash.empty?
     assert_redirected_to root_url
   end
-  
 end

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -1,38 +1,37 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class UsersEditTest < ActionDispatch::IntegrationTest
-
   def setup
     @user = users(:ito)
   end
 
-  test "unsuccessful edit" do
+  test 'unsuccessful edit' do
     log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
-    patch user_path(@user), params: { user: { name:  "",
-                                              email: "soneda@invalid",
-                                              password:              "foo",
-                                              password_confirmation: "bar" } }
+    patch user_path(@user), params: { user: { name:  '',
+                                              email: 'soneda@invalid',
+                                              password:              'foo',
+                                              password_confirmation: 'bar' } }
 
     assert_template 'users/edit'
   end
-  
-  test "successful edit" do
+
+  test 'successful edit' do
     log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
-    name  = "sone da"
-    email = "sone@bar.com"
+    name  = 'sone da'
+    email = 'sone@bar.com'
     patch user_path(@user), params: { user: { name:  name,
                                               email: email,
-                                              password:              "",
-                                              password_confirmation: "" } }
+                                              password:              '',
+                                              password_confirmation: '' } }
     assert_not flash.empty?
     assert_redirected_to @user
     @user.reload
     assert_equal name,  @user.name
     assert_equal email, @user.email
   end
-  
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -1,37 +1,36 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class UsersLoginTest < ActionDispatch::IntegrationTest
-
   # フィクスチャからユーザを取得し設定
   def setup
     @user = users(:ito)
   end
-  
-  test "login with invalid information" do
+
+  test 'login with invalid information' do
     get login_path
     assert_template 'sessions/new'
-    post login_path, params: { session: { email: "", password: "" } }
+    post login_path, params: { session: { email: '', password: '' } }
     assert_template 'sessions/new'
     assert_not flash.empty?
     get root_path
     assert flash.empty?
   end
-  
-  test "login with valid information followed by logout" do
+
+  test 'login with valid information followed by logout' do
     get login_path
     post login_path, params: { session: { email:    @user.email,
                                           password: 'password' } }
     assert_redirected_to @user
     follow_redirect!
     assert_template 'users/show'
-    assert_select "a[href=?]", login_path, count: 0
-    assert_select "a[href=?]", logout_path
+    assert_select 'a[href=?]', login_path, count: 0
+    assert_select 'a[href=?]', logout_path
     delete logout_path
     assert_redirected_to root_url
-    delete logout_path  # 2番目のウィンドウでログアウトをクリックするユーザーをシミュレートする
+    delete logout_path # 2番目のウィンドウでログアウトをクリックするユーザーをシミュレートする
     follow_redirect!
-    assert_select "a[href=?]", login_path
-    assert_select "a[href=?]", logout_path,      count: 0
+    assert_select 'a[href=?]', login_path
+    assert_select 'a[href=?]', logout_path, count: 0
   end
-  
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,22 +1,22 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
-  
   def setup
     ActionMailer::Base.deliveries.clear
   end
-  
-  test "invalid signup information" do
+
+  test 'invalid signup information' do
     get signup_path
     assert_no_difference 'User.count' do
-      post users_path, params: { user: { name:  "",
-                                         email: "user@invalid",
-                                         password:              "foo",
-                                         password_confirmation: "bar" } }
+      post users_path, params: { user: { name:  '',
+                                         email: 'user@invalid',
+                                         password:              'foo',
+                                         password_confirmation: 'bar' } }
     end
     assert_template 'users/new'
   end
-  
+
   #  test "valid signup information with account activation" do
   #    get signup_path
   #    assert_difference 'User.count', 1 do
@@ -43,5 +43,4 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
   #    follow_redirect!
   #    assert is_logged_in?
   #  end
-  
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,6 +1,6 @@
+# frozen_string_literal: true
 # Preview all emails at https://whiteboard-mfito.c9users.io/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
-
   # Preview this email at
   # https://whiteboard-mfito.c9users.io/rails/mailers/user_mailer/account_activation
   def account_activation

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
-
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,77 +1,76 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-
   # テスト用にユーザーを追加
   def setup
-    @user = User.new(name: "Ito Masafumi", email: "ito@example.com",
-                     password: "foobar", password_confirmation: "foobar")
+    @user = User.new(name: 'Ito Masafumi', email: 'ito@example.com',
+                     password: 'foobar', password_confirmation: 'foobar')
   end
 
-  test "should be valid" do
+  test 'should be valid' do
     assert @user.valid?
   end
 
-  test "name should be present" do
-    @user.name = "     "
-    assert_not @user.valid?
-  end
-  
-  test "email should be present" do
-    @user.email = "     "
-    assert_not @user.valid?
-  end
-  
-  test "name should not be too long" do
-    @user.name = "a" * 51
+  test 'name should be present' do
+    @user.name = '     '
     assert_not @user.valid?
   end
 
-  test "email should not be too long" do
-    @user.email = "a" * 244 + "@example.com"
+  test 'email should be present' do
+    @user.email = '     '
     assert_not @user.valid?
   end
-  
-  test "email validation should accept valid addresses" do
-    valid_addresses = %w[soneda@example.com SONEDA@foo.COM A_US-ER@foo.bar.org
-                         soneda.takuya@foo.jp ito+soneda@baz.cn]
+
+  test 'name should not be too long' do
+    @user.name = 'a' * 51
+    assert_not @user.valid?
+  end
+
+  test 'email should not be too long' do
+    @user.email = 'a' * 244 + '@example.com'
+    assert_not @user.valid?
+  end
+
+  test 'email validation should accept valid addresses' do
+    valid_addresses = %w(soneda@example.com SONEDA@foo.COM A_US-ER@foo.bar.org
+                         soneda.takuya@foo.jp ito+soneda@baz.cn)
     valid_addresses.each do |valid_address|
       @user.email = valid_address
       assert @user.valid?, "#{valid_address.inspect} should be valid"
     end
   end
-  
-  test "email validation should reject invalid addresses" do
-    invalid_addresses = %w[user@example,com user_at_foo.org user.name@example.
-                           foo@bar_baz.com foo@bar+baz.com]
+
+  test 'email validation should reject invalid addresses' do
+    invalid_addresses = %w(user@example,com user_at_foo.org user.name@example.
+                           foo@bar_baz.com foo@bar+baz.com)
     invalid_addresses.each do |invalid_address|
       @user.email = invalid_address
       assert_not @user.valid?, "#{invalid_address.inspect} should be invalid"
     end
   end
-  
-  test "email addresses should be unique" do
+
+  test 'email addresses should be unique' do
     duplicate_user = @user.dup
     duplicate_user.email = @user.email.upcase
     @user.save
     assert_not duplicate_user.valid?
   end
-  
-  test "email addresses should be saved as lower-case" do
-    mixed_case_email = "Ito@ExAMPle.CoM"
+
+  test 'email addresses should be saved as lower-case' do
+    mixed_case_email = 'Ito@ExAMPle.CoM'
     @user.email = mixed_case_email
     @user.save
     assert_equal mixed_case_email.downcase, @user.reload.email
   end
-  
-  test "password should be present (nonblank)" do
-    @user.password = @user.password_confirmation = " " * 6
+
+  test 'password should be present (nonblank)' do
+    @user.password = @user.password_confirmation = ' ' * 6
     assert_not @user.valid?
   end
 
-  test "password should have a minimum length" do
-    @user.password = @user.password_confirmation = "a" * 5
+  test 'password should have a minimum length' do
+    @user.password = @user.password_confirmation = 'a' * 5
     assert_not @user.valid?
   end
-  
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
@@ -18,12 +19,10 @@ class ActiveSupport::TestCase
 end
 
 class ActionDispatch::IntegrationTest
-
   # テストユーザーとしてログインする
   def log_in_as(user, password: 'password', remember_me: '1')
     post login_path, params: { session: { email: user.email,
                                           password: password,
                                           remember_me: remember_me } }
   end
-  
 end


### PR DESCRIPTION
新規登録したときのアカウント有効化メールを再送信する機能の追加

アカウント有効化していない状態でログインしようとしたら、「アカウント有効化メール再送信」リンクをフラッシュで表示する